### PR TITLE
Update example context file to ensure unique 'base' namespace due to …

### DIFF
--- a/staging/example/v0.1/context.jsonld
+++ b/staging/example/v0.1/context.jsonld
@@ -2,10 +2,6 @@
         "@context": [
                 "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
                 {
-                    "base": {
-                        "@id": "https://industryfusion.github.io/contexts/example/v0/base_knowledge/",
-                        "@prefix": true
-                    },
                     "eclass": {
                         "@id": "https://industry-fusion.org/eclass#",
                         "@prefix": true
@@ -38,7 +34,7 @@
                         "@id": "https://industryfusion.github.io/contexts/example/v0/base_entities/",
                         "@prefix": true
                     },
-                    "iffBaseKnowledge": {
+                    "base": {
                         "@id": "https://industryfusion.github.io/contexts/example/v0/base_knowledge/",
                         "@prefix": true
                     },


### PR DESCRIPTION
…difficulties

of RDFLib to parse dupliate namespaces